### PR TITLE
Added id3 support to FLAC in GetImageFromFileMetadata

### DIFF
--- a/Code/Engine/Audio/Audio.cpp
+++ b/Code/Engine/Audio/Audio.cpp
@@ -260,7 +260,11 @@ void AudioSystem::PrintTag(SoundID soundID)
 {
     TagLib::FileRef audioFile("IF.mp3");
     TagLib::String artist = audioFile.tag()->artist();
+    TagLib::String album = audioFile.tag()->album();
+    int year = audioFile.tag()->year();
     Console::instance->PrintLine(Stringf("Artist: %s\n", artist.toCString()));
+    Console::instance->PrintLine(Stringf("Album: %s\n", album.toCString()));
+    Console::instance->PrintLine(Stringf("Year: %i\n", year));
 
     unsigned int numSounds = m_registeredSounds.size();
     if (soundID < 0 || soundID >= numSounds)

--- a/Code/Engine/Audio/AudioMetadataUtils.cpp
+++ b/Code/Engine/Audio/AudioMetadataUtils.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------------
 std::string GetFileExtension(const std::string& fileName)
 {
-    // Find the file extension
+    //Find the file extension
     unsigned extensionPos = fileName.rfind('.');
 
     if (extensionPos != std::string::npos && extensionPos != fileName.length())
@@ -48,7 +48,7 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
     unsigned char* srcImage = nullptr;
     unsigned long size;
 
-    // Find the file extension
+    //Find the file extension
     std::string fileExtension = GetFileExtension(fileName);
     if (fileExtension == "mp3")
     {
@@ -61,16 +61,16 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
             TagLib::ID3v2::FrameList Frame;
             TagLib::ID3v2::AttachedPictureFrame* PicFrame;
 
-            // picture frame
+            //Picture frame
             Frame = id3v2tag->frameListMap()[IdPicture];
             if (!Frame.isEmpty())
             {
                 for (TagLib::ID3v2::FrameList::ConstIterator it = Frame.begin(); it != Frame.end(); ++it)
                 {
-                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame *)(*it);
+                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame*)(*it);
                     if (PicFrame->type() == TagLib::ID3v2::AttachedPictureFrame::FrontCover)
                     {
-                        // extract image (in it’s compressed form)
+                        //Extract image (in it’s compressed form)
                         TagLib::ByteVector pictureData = PicFrame->picture();
                         size = pictureData.size();
                         srcImage = (unsigned char*)pictureData.data();
@@ -86,13 +86,15 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
     else if (fileExtension == "flac")
     {
         TagLib::FLAC::File audioFile(fileName.c_str());
-        if (!audioFile.pictureList().isEmpty())
+		auto pictureList = audioFile.pictureList();
+
+        if (!pictureList.isEmpty())
         {
             for (unsigned i = 0; i < audioFile.pictureList().size(); ++i)
             {
-                if (audioFile.pictureList()[i]->type() == TagLib::FLAC::Picture::Type::FrontCover)
+                if (pictureList[i]->type() == TagLib::FLAC::Picture::Type::FrontCover)
                 {
-                    TagLib::ByteVector pictureData = audioFile.pictureList()[i]->data();
+                    TagLib::ByteVector pictureData = pictureList[i]->data();
                     size = pictureData.size();
                     srcImage = (unsigned char*)pictureData.data();
                     if (srcImage)
@@ -109,16 +111,16 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
             TagLib::ID3v2::FrameList Frame;
             TagLib::ID3v2::AttachedPictureFrame* PicFrame;
 
-            // picture frame
+            //Picture frame
             Frame = id3v2tag->frameListMap()[IdPicture];
             if (!Frame.isEmpty())
             {
                 for (TagLib::ID3v2::FrameList::ConstIterator it = Frame.begin(); it != Frame.end(); ++it)
                 {
-                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame *)(*it);
+                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame*)(*it);
                     if (PicFrame->type() == TagLib::ID3v2::AttachedPictureFrame::FrontCover)
                     {
-                        // extract image (in it’s compressed form)
+                        //Extract image (in it’s compressed form)
                         TagLib::ByteVector pictureData = PicFrame->picture();
                         size = pictureData.size();
                         srcImage = (unsigned char*)pictureData.data();
@@ -141,16 +143,16 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
 
         if (audioFile.hasID3v2Tag())
         {
-            // picture frame
+            //Picture frame
             Frame = id3v2tag->frameListMap()[IdPicture];
             if (!Frame.isEmpty())
             {
                 for (TagLib::ID3v2::FrameList::ConstIterator it = Frame.begin(); it != Frame.end(); ++it)
                 {
-                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame *)(*it);
+                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame*)(*it);
                     if (PicFrame->type() == TagLib::ID3v2::AttachedPictureFrame::FrontCover)
                     {
-                        // extract image (in it’s compressed form)
+                        //Extract image (in it’s compressed form)
                         TagLib::ByteVector pictureData = PicFrame->picture();
                         size = pictureData.size();
                         srcImage = (unsigned char*)pictureData.data();

--- a/Code/Engine/Audio/AudioMetadataUtils.cpp
+++ b/Code/Engine/Audio/AudioMetadataUtils.cpp
@@ -52,14 +52,15 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
     std::string fileExtension = GetFileExtension(fileName);
     if (fileExtension == "mp3")
     {
-        static const char* IdPicture = "APIC";
         TagLib::MPEG::File audioFile(fileName.c_str());
-        TagLib::ID3v2::Tag* id3v2tag = audioFile.ID3v2Tag();
-        TagLib::ID3v2::FrameList Frame;
-        TagLib::ID3v2::AttachedPictureFrame* PicFrame;
 
         if (audioFile.hasID3v2Tag())
         {
+            static const char* IdPicture = "APIC";
+            TagLib::ID3v2::Tag* id3v2tag = audioFile.ID3v2Tag();
+            TagLib::ID3v2::FrameList Frame;
+            TagLib::ID3v2::AttachedPictureFrame* PicFrame;
+
             // picture frame
             Frame = id3v2tag->frameListMap()[IdPicture];
             if (!Frame.isEmpty())
@@ -97,6 +98,34 @@ Texture* GetImageFromFileMetadata(const std::string& fileName)
                     if (srcImage)
                     {
                         return Texture::CreateUnregisteredTextureFromData(srcImage, size);
+                    }
+                }
+            }
+        }
+        else if (audioFile.hasID3v2Tag())
+        {
+            static const char* IdPicture = "APIC";
+            TagLib::ID3v2::Tag* id3v2tag = audioFile.ID3v2Tag();
+            TagLib::ID3v2::FrameList Frame;
+            TagLib::ID3v2::AttachedPictureFrame* PicFrame;
+
+            // picture frame
+            Frame = id3v2tag->frameListMap()[IdPicture];
+            if (!Frame.isEmpty())
+            {
+                for (TagLib::ID3v2::FrameList::ConstIterator it = Frame.begin(); it != Frame.end(); ++it)
+                {
+                    PicFrame = (TagLib::ID3v2::AttachedPictureFrame *)(*it);
+                    if (PicFrame->type() == TagLib::ID3v2::AttachedPictureFrame::FrontCover)
+                    {
+                        // extract image (in it’s compressed form)
+                        TagLib::ByteVector pictureData = PicFrame->picture();
+                        size = pictureData.size();
+                        srcImage = (unsigned char*)pictureData.data();
+                        if (srcImage)
+                        {
+                            return Texture::CreateUnregisteredTextureFromData(srcImage, size);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixed issue in picoriley/MusicPlayer#1 where application would crash when loading an id3 tagged FLAC file.